### PR TITLE
Improve loaders to use the vendor chunk and reduce their size 

### DIFF
--- a/src/NativeScriptWorkerPlugin.js
+++ b/src/NativeScriptWorkerPlugin.js
@@ -34,8 +34,6 @@ exports.NativeScriptWorkerPlugin = (function () {
                             this.addAsset(compilation, fileName.replace(".worker.js", ".starter.js"), this.generateStarterModule(fileName))
 
                             workersFullPath.push(resolve(compiler.outputPath, fileName));
-                            // console.log(join(compiler.outputPath, fileName));
-                            // return;
                         }
                     }
                 }
@@ -53,7 +51,11 @@ exports.NativeScriptWorkerPlugin = (function () {
     };
 
     NativeScriptWorkerPlugin.prototype.generateStarterModule = function (worker) {
-        return `require("./${this.commonChunkName}");
+        // global.__worker is used to prevent loading UI related imports from the vendor chunk inside the worker
+        return `
+global = global || {};
+global.__worker = true;
+require("./${this.commonChunkName}");
 require("./${parse(worker).name}");`
     }
 

--- a/src/NativeScriptWorkerPlugin.js
+++ b/src/NativeScriptWorkerPlugin.js
@@ -11,6 +11,10 @@ exports.NativeScriptWorkerPlugin = (function () {
         compiler.plugin("this-compilation", (compilation) => {
             
             compilation.plugin(["optimize-chunks"], (chunks) => {
+                if (!compilation.workerFiles) {
+                    return;
+                }
+
                 const workersFullPath = [];
 
                 for (const chunk of chunks) {

--- a/src/NativeScriptWorkerPlugin.js
+++ b/src/NativeScriptWorkerPlugin.js
@@ -1,28 +1,64 @@
-const { resolve } = require("path");
+const { parse, resolve } = require("path");
 const { RawSource } = require("webpack-sources");
 
 exports.NativeScriptWorkerPlugin = (function () {
-    function NativeScriptWorkerPlugin() {
+    function NativeScriptWorkerPlugin({commonChunkName}) {
+        this.files = {};
+        this.commonChunkName = commonChunkName;
     }
 
     NativeScriptWorkerPlugin.prototype.apply = function (compiler) {
-        compiler.plugin("emit", (compilation, cb) => {
-            if (!compilation.workerChunks) {
-                return cb();
-            }
+        compiler.plugin("this-compilation", (compilation) => {
+            
+            compilation.plugin(["optimize-chunks"], (chunks) => {
+                const workersFullPath = [];
 
-            const output = compiler.outputPath;
-            const workersFullPath = compilation.workerChunks
-                .map(chunk => resolve(output, chunk));
+                for (const chunk of chunks) {
+                    if (chunk._isWorkerExtractedIn) {
+                        continue;
+                    }
+                    for (const module of chunk.modulesIterable) {
+                        if (compilation.workerFiles.has(module.request)) {
+                            const fileName = compilation.workerFiles.get(module.request)
+                            const workerChunk = compilation.addChunk(fileName);
+                            
+                            workerChunk.filenameTemplate = fileName
+                            chunk.moveModule(module, workerChunk);
+                            workerChunk.entryModule = module;
+                            workerChunk._isWorkerExtractedIn = true;
 
-            const content = JSON.stringify(workersFullPath, null, 4);
-            const source = new RawSource(content);
+                            this.addAsset(compilation, fileName.replace(".worker.js", ".starter.js"), this.generateStarterModule(fileName))
 
-            compilation.assets["__worker-chunks.json"] = source;
+                            workersFullPath.push(resolve(compiler.outputPath, fileName));
+                            // console.log(join(compiler.outputPath, fileName));
+                            // return;
+                        }
+                    }
+                }
 
-            cb();
+                if (workersFullPath.length === 0) {
+                    return;
+                }
+                
+                const content = JSON.stringify(workersFullPath, null, 4);
+                const source = new RawSource(content);
+    
+                compilation.assets["__worker-chunks.json"] = source;
+            });            
         });
     };
+
+    NativeScriptWorkerPlugin.prototype.generateStarterModule = function (worker) {
+        return `require("./${this.commonChunkName}");
+require("./${parse(worker).name}");`
+    }
+
+    NativeScriptWorkerPlugin.prototype.addAsset = function(compilation, name, content) {
+        if (this.files[name] !== content) {
+            this.files[name] = content;
+            compilation.assets[name] = new RawSource(content);
+        }
+    }
 
     return NativeScriptWorkerPlugin;
 }());

--- a/src/NativeScriptWorkerPlugin.js
+++ b/src/NativeScriptWorkerPlugin.js
@@ -2,9 +2,11 @@ const { parse, resolve } = require("path");
 const { RawSource } = require("webpack-sources");
 
 exports.NativeScriptWorkerPlugin = (function () {
-    function NativeScriptWorkerPlugin({commonChunkName}) {
+    function NativeScriptWorkerPlugin(options) {
+        options = options || {};
+
         this.files = {};
-        this.commonChunkName = commonChunkName;
+        this.commonChunkName = options.commonChunkName || "vendor";
     }
 
     NativeScriptWorkerPlugin.prototype.apply = function (compiler) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { basename } = require("path");
 const loaderUtils = require("loader-utils");
 const validateOptions = require("schema-utils");
 const optionsSchema = require("./options.json");
@@ -39,7 +40,12 @@ module.exports = function workerLoader(content, map, meta) {
 
     this._compilation.workerFiles.set(this.data.path, `${filenamePrefix}.worker.js`);
 
-    return `module.exports = function() {\n\treturn ${getWorker(filenamePrefix + ".starter.js")};\n};`;
+    // require.context is used only to add the module as dependency so webpack can build it
+    return `
+module.exports = function() {
+    require.context("~/", true, /${basename(this.data.path)}$/);
+    return ${getWorker(filenamePrefix + ".starter.js")};
+};`;
 };
 
 module.exports.pitch = function (request, preceding, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,6 @@
 
 const loaderUtils = require("loader-utils");
 const validateOptions = require("schema-utils");
-const WebWorkerTemplatePlugin = require("webpack/lib/webworker/WebWorkerTemplatePlugin");
-const NodeTargetPlugin = require("webpack/lib/node/NodeTargetPlugin");
-const SingleEntryPlugin = require("webpack/lib/SingleEntryPlugin");
 const optionsSchema = require("./options.json");
 
 const validateSchema = (schema, options, pluginName) => {
@@ -32,71 +29,19 @@ const getWorker = file => {
     return `new Worker(${workerPublicPath})`;
 };
 
-module.exports = function workerLoader() {};
+module.exports = function workerLoader(content, map, meta) {
+    this._compilation.workerFiles = this._compilation.workerFiles || new Map();
 
-module.exports.pitch = function pitch(request) {
-    if (!this.webpack) {
-        throw new Error("Only usable with webpack");
-    }
-
-    this.cacheable(false);
-    const callback = this.async();
-    const options = loaderUtils.getOptions(this) || {};
-    validateSchema(optionsSchema, options, "Worker Loader");
-    this._compilation.workerChunks = [];
-
-    const filename = loaderUtils.interpolateName(this, options.name || "[hash].worker.js", {
-        context: options.context || this.options.context,
-        regExp: options.regExp,
+    const filenamePrefix = loaderUtils.interpolateName(this, "[hash]", {
+        context: this.context,
+        content,
     });
 
-    const outputOptions = {
-        filename,
-        chunkFilename: `[id].${filename}`,
-        namedChunkFilename: null,
-    };
+    this._compilation.workerFiles.set(this.data.path, `${filenamePrefix}.worker.js`);
 
-    if (this.options && this.options.worker && this.options.worker.output) {
-        Object.keys(this.options.worker.output).forEach((name) => {
-            outputOptions[name] = this.options.worker.output[name];
-        });
-    }
-
-    const workerCompiler = this._compilation.createChildCompiler("worker", outputOptions);
-    workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-    if (this.target !== "webworker" && this.target !== "web") {
-        workerCompiler.apply(new NodeTargetPlugin());
-    }
-
-    workerCompiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, "main"));
-    if (this.options && this.options.worker && this.options.worker.plugins) {
-        this.options.worker.plugins.forEach(plugin => workerCompiler.apply(plugin));
-    }
-
-    const subCache = `subcache ${__dirname} ${request}`;
-    workerCompiler.plugin("compilation", compilation => {
-        if (compilation.cache) {
-            if (!compilation.cache[subCache]) {
-                compilation.cache[subCache] = {};
-            }
-            compilation.cache = compilation.cache[subCache];
-        }
-    });
-
-    workerCompiler.runAsChild((err, entries) => {
-        if (err) {
-            return callback(err);
-        }
-
-        if (entries[0]) {
-            const workerFile = entries[0].files[0];
-            this._compilation.workerChunks.push(workerFile);
-            const workerFactory = getWorker(workerFile);
-
-            return callback(null, `module.exports = function() {\n\treturn ${workerFactory};\n};`);
-        }
-
-        return callback(null, null);
-    });
+    return `module.exports = function() {\n\treturn ${getWorker(filenamePrefix + ".starter.js")};\n};`;
 };
 
+module.exports.pitch = function (request, preceding, data) {
+    data.path = request;
+};

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -614,6 +614,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1328,6 +1329,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2157,6 +2947,12 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2932,14 +3728,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2967,6 +3755,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {


### PR DESCRIPTION
Fixes #5. 

Instead of child compiling workers (which does not reuse the common chunk and increases worker size) this change makes webpack compile the workers in the main bundle. This way it reuses requires from the vendor chunk. After the compile the plugin extracts each worker module in a separate chunk file and also creates a similar to the `starter.js` file for every worker. 
In order the vendor chunk to be reused inside the workers, any UI related imports need to be excluded for the worker. That's why the starter file for the worker raises a `global.__worker` flag which is then used in the vendor file to conditionally import the UI modules. 