### PR TITLE
fix: handle calls to itself to avoid an infinite loop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const getWorker = file => {
 
 module.exports = function workerLoader() { };
 
-let requests = [];
+const requests = [];
 
 module.exports.pitch = function pitch(request) {
     if (!this.webpack) {
@@ -76,7 +76,7 @@ module.exports.pitch = function pitch(request) {
     new SingleEntryPlugin(this.context, `!!${request}`, "main").apply(workerCompiler);
 
     const subCache = `subcache ${__dirname} ${request}`;
-    const plugin = { name: 'WorkerLoader' };
+    const plugin = { name: "WorkerLoader" };
 
     workerCompiler.hooks.compilation.tap(plugin, compilation => {
         if (compilation.cache) {

--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,20 @@ const getWorker = file => {
     return `new Worker(${workerPublicPath})`;
 };
 
-module.exports = function workerLoader() {};
+module.exports = function workerLoader() { };
+
+let requests = [];
 
 module.exports.pitch = function pitch(request) {
     if (!this.webpack) {
         throw new Error("Only usable with webpack");
+    }
+
+    // handle calls to itself to avoid an infinite loop
+    if (requests.indexOf(request) === -1) {
+        requests.push(request);
+    } else {
+        return "";
     }
 
     this.cacheable(false);
@@ -68,7 +77,7 @@ module.exports.pitch = function pitch(request) {
 
     const subCache = `subcache ${__dirname} ${request}`;
     const plugin = { name: 'WorkerLoader' };
- 
+
     workerCompiler.hooks.compilation.tap(plugin, compilation => {
         if (compilation.cache) {
             if (!compilation.cache[subCache]) {


### PR DESCRIPTION
In case the `nativescript-worker-loader` calls itself, it cases an infinite loop of creating a new worker chunk for each call and results in webpack compiler out of memory exception.

Error:
```
RangeError: Maximum call stack size exceeded
```

Fixes: https://github.com/NativeScript/worker-loader/issues/33.