### PR TITLE
Adding customDomain option to suppot fetching worker script from othe…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,15 @@ const validateSchema = (schema, options, pluginName) => {
     validateOptions(schema, options, pluginName);
 };
 
-const getPublicPath = file => {
-    const root = JSON.stringify("./");
+const getPublicPath = (file, customDomain) => {
+    const root = customDomain ? "" : JSON.stringify("./ + ");
     const filePath = JSON.stringify(file);
 
-    return `${root} + __webpack_public_path__ + ${filePath}`;
+    return `${root}__webpack_public_path__ + ${filePath}`;
 };
 
-const getWorker = file => {
-    const workerPublicPath = getPublicPath(file);
+const getWorker = (file, customDomain) => {
+    const workerPublicPath = getPublicPath(file, customDomain);
     return `new Worker(${workerPublicPath})`;
 };
 
@@ -107,7 +107,7 @@ module.exports.pitch = function pitch(request) {
         if (entries[0]) {
             const workerFile = entries[0].files[0];
             this._compilation.workerChunks.push(workerFile);
-            const workerFactory = getWorker(workerFile);
+            const workerFactory = getWorker(workerFile, options.customDomain);
 
             // invalidate cache
             const processedIndex = requests.indexOf(request);

--- a/src/options.json
+++ b/src/options.json
@@ -9,6 +9,9 @@
     },
     "fallback": {
       "type": "boolean"
+    },
+    "customDomain": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Addin customDomain option to fix [download worker script from other domain (cdn)  issue](https://github.com/NativeScript/worker-loader/issues/42).

This option enable to download the worker script from an external domain.
Should be used when __webpack_public_path__ points to "https://domain..".