### PR TITLE
Kddimitrov/fix worker loader cachable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,11 @@ module.exports.pitch = function pitch(request) {
 
     workerCompiler.hooks.thisCompilation.tap(plugin, compilation => {
         /**
-         * A dirty hack to disable HMR plugin in childCompilation - https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/HotModuleReplacementPlugin.js#L154;
-         * Once we update to webpack@4.40.3 and above this can be removed - https://github.com/webpack/webpack/commit/1c4138d6ac04b7b47daa5ec4475c0ae1b4f596a2
+         * A dirty hack to disable HMR plugin in childCompilation:
+         * https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/HotModuleReplacementPlugin.js#L154
+         *
+         * Once we update to webpack@4.40.3 and above this can be removed:
+         * https://github.com/webpack/webpack/commit/1c4138d6ac04b7b47daa5ec4475c0ae1b4f596a2
          */
         compilation.hotUpdateChunkTemplate = null;
     });
@@ -110,8 +113,11 @@ module.exports.pitch = function pitch(request) {
                 this.addDependency(fileName);
             });
             /**
-             * Clears the hash of the child compilation as it affects the hash of the parent compilation - https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/Compilation.js#L2281
-             * If we don't clear the hash an emit of runtime.js and an empty [somehash].hot-update.json will happen, which will restart the NS application.
+             * Clears the hash of the child compilation as it affects the hash of the parent compilation:
+             * https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/Compilation.js#L2281
+             *
+             * If we don't clear the hash an emit of runtime.js and an empty [somehash].hot-update.json will happen on save without changes.
+             * This will restart the NS application.
              */
             childCompilation.hash = "";
             const workerFile = entries[0].files[0];

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-worker-loader",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "author": "NativeScript team",
   "description": "nativescript worker loader module for webpack",
   "scripts": {


### PR DESCRIPTION
The worker loader was marked as non cachable - [here](https://github.com/NativeScript/worker-loader/blob/73826763ec42712c575498212d2480a651e9bce4/src/index.js#L45), which caused a new child compilation and new emit on every change - [source here](https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/NormalModule.js#L524).

When the cache disable is removed initially(after first compilation) the worker files are added as a dependency and watched, because the file dependencies of the child compilation are added to the fileDependencies of the parent compilation - [here](https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/Compilation.js#L2224).

After the first change webpack doesn't find any [module dependent on the files](https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/NormalModule.js#L529) and the loader result is cached, so no child compilation is started. This results in that the watcher no longer is even watching the files - [source here](https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/Watching.js#L100).

To fix this, we should take all file dependencies of the child compilation and add them to the file dependencies of the module. Now this method will mark the module as one that [needs rebuild](https://github.com/webpack/webpack/blob/4056506488c1e071dfc9a0127daa61bf531170bf/lib/NormalModule.js#L529) which will in turn invoke the loader logic.

Fixes https://github.com/NativeScript/worker-loader/issues/41